### PR TITLE
build,protobuf: stop building unnecessary protobuf

### DIFF
--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -15,64 +15,8 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_primitive_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_service.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_string_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_field_base.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_helpers.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_map_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_message.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_message_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_reflection_class.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_source_generator_base.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_context.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_doc_comment.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_enum.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_enum_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_enum_field_lite.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_enum_lite.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_extension.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_extension_lite.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_file.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_generator_factory.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_helpers.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_map_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_map_field_lite.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_message.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_message_builder.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_message_builder_lite.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_message_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_message_field_lite.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_message_lite.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_name_resolver.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_primitive_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_primitive_field_lite.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_service.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_shared_code_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_string_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_string_field_lite.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/js/js_generator.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types_embed.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_extension.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_file.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_map_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_message.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_message_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_oneof.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/php/php_generator.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/plugin.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/plugin.pb.cc

--- a/src/google/protobuf/compiler/main.cc
+++ b/src/google/protobuf/compiler/main.cc
@@ -63,9 +63,9 @@ int ProtobufMain(int argc, char* argv[]) {
 #endif
 
   // Proto2 Java
-  java::JavaGenerator java_generator;
-  cli.RegisterGenerator("--java_out", "--java_opt", &java_generator,
-                        "Generate Java source file.");
+  // java::JavaGenerator java_generator;
+  // cli.RegisterGenerator("--java_out", "--java_opt", &java_generator,
+  //                       "Generate Java source file.");
 
 
   // Proto2 Python
@@ -84,14 +84,14 @@ int ProtobufMain(int argc, char* argv[]) {
                         "Generate Ruby source file.");
 
   // CSharp
-  csharp::Generator csharp_generator;
-  cli.RegisterGenerator("--csharp_out", "--csharp_opt", &csharp_generator,
-                        "Generate C# source file.");
+  // csharp::Generator csharp_generator;
+  // cli.RegisterGenerator("--csharp_out", "--csharp_opt", &csharp_generator,
+  //                       "Generate C# source file.");
 
   // Objective C
-  objectivec::ObjectiveCGenerator objc_generator;
-  cli.RegisterGenerator("--objc_out", "--objc_opt", &objc_generator,
-                        "Generate Objective C header and source.");
+  // objectivec::ObjectiveCGenerator objc_generator;
+  // cli.RegisterGenerator("--objc_out", "--objc_opt", &objc_generator,
+  //                       "Generate Objective C header and source.");
 
   // JavaScript
   js::Generator js_generator;


### PR DESCRIPTION
Based on dev-inf#56 we need to avoid protobuf compiler to run for Java, Obj-C and C# everytime we build as no one is using these languages anymore.

Release note: None